### PR TITLE
Updated quickstart configs to support recent Kratos versions

### DIFF
--- a/quickstart/config/kratos/email-password/.kratos.yml
+++ b/quickstart/config/kratos/email-password/.kratos.yml
@@ -22,7 +22,7 @@ selfservice:
       privileged_session_max_age: 15m
 
     recovery:
-      enabled: false # Not supported by UI service
+      enabled: true
       ui_url: http://127.0.0.1:3000/recovery
 
     verification:

--- a/quickstart/config/kratos/email-password/.kratos.yml
+++ b/quickstart/config/kratos/email-password/.kratos.yml
@@ -1,58 +1,59 @@
+serve:
+  public:
+    base_url: http://localhost:3000/.ory/kratos/public/
+  admin:
+    base_url: http://kratos:4434/
+
 selfservice:
+  default_browser_return_url: http://localhost:3000/
+  whitelisted_return_urls:
+    - http://localhost:3000
+
   strategies:
     password:
       enabled: true
 
-  settings:
-    privileged_session_max_age: 1m
-    after:
-      profile:
-        hooks:
-          -
-            hook: verify
+  flows:
+    error:
+      ui_url: http://localhost:3000/error
 
-  verify:
-    return_to: http://localhost:3000/
+    settings:
+      ui_url: http://localhost:3000/settings
+      privileged_session_max_age: 15m
 
-  logout:
-    redirect_to: http://localhost:3000/auth/login
+    recovery:
+      enabled: false # Not supported by UI service
+      ui_url: http://127.0.0.1:3000/recovery
 
-  login:
-    request_lifespan: 10m
+    verification:
+      enabled: true
+      ui_url: http://localhost:3000/verify
+      after:
+        default_browser_return_url: http://localhost:3000/
 
-  registration:
-    request_lifespan: 10m
-    after:
-      password:
-        hooks:
-          -
-            hook: session
-          -
-            hook: verify
+    logout:
+      after:
+        default_browser_return_url: http://localhost:3000/auth/login
+
+    login:
+      ui_url: http://localhost:3000/auth/login
+      request_lifespan: 10m
+
+    registration:
+      request_lifespan: 10m
+      ui_url: http://localhost:3000/auth/registration
+      after:
+        password:
+          hooks:
+            -
+              hook: session
 
 log:
   level: debug
 
 secrets:
-  session:
+  cookie:
     - PLEASE-CHANGE-ME-I-AM-VERY-INSECURE
-
-urls:
-  login_ui: http://localhost:3000/auth/login
-  registration_ui: http://localhost:3000/auth/registration
-  error_ui: http://localhost:3000/error
-  settings_ui: http://localhost:3000/settings
-  verify_ui: http://localhost:3000/verify
-
-  # These are undefined because not available in this demo
-  mfa_ui: http://localhost:3000/
-
-  self:
-    public: http://localhost:3000/.ory/kratos/public/
-    admin: http://kratos:4434/
-  default_return_to: http://localhost:3000/
-  whitelisted_return_to_urls:
-    - http://localhost:3000/
 
 hashers:
   argon2:
@@ -63,8 +64,7 @@ hashers:
     key_length: 16
 
 identity:
-  traits:
-    default_schema_url: file:///etc/config/kratos/identity.traits.schema.json
+  default_schema_url: file:///etc/config/kratos/identity.traits.schema.json
 
 courier:
   smtp:

--- a/quickstart/config/kratos/email-password/identity.traits.schema.json
+++ b/quickstart/config/kratos/email-password/identity.traits.schema.json
@@ -4,25 +4,33 @@
   "title": "Person",
   "type": "object",
   "properties": {
-    "email": {
-      "type": "string",
-      "format": "email",
-      "title": "E-Mail",
-      "minLength": 3,
-      "ory.sh/kratos": {
-        "credentials": {
-          "password": {
-            "identifier": true
+    "traits": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "format": "email",
+          "title": "E-Mail",
+          "minLength": 3,
+          "ory.sh/kratos": {
+            "credentials": {
+              "password": {
+                "identifier": true
+              }
+            },
+            "verification": {
+              "via": "email"
+            },
+            "recovery": {
+              "via": "email"
+            }
           }
-        },
-        "verification": {
-          "via": "email"
         }
-      }
+      },
+      "required": [
+        "email"
+      ],
+      "additionalProperties": false
     }
-  },
-  "required": [
-    "email"
-  ],
-  "additionalProperties": false
+  }
 }


### PR DESCRIPTION
It didn't work with kratos:latest anymore. Only kratos:v3 was supported.
I've customized default configs from kratos v0.4(latest) quickstart to work with Your fork of UI.
